### PR TITLE
Add simple custom panel integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,15 @@
+# Home Assistant Custom UI Panel
+
+This repository provides an example of a very simple custom integration for Home Assistant that adds a custom panel to the sidebar. The panel displays a static HTML page served by the integration.
+
+## Installation
+
+1. Copy the `custom_components/custom_ui_panel` folder into the `config/custom_components/` directory of your Home Assistant instance.
+2. Restart Home Assistant.
+3. After restart, a new sidebar entry called **Custom Panel** will appear. Selecting it will open the HTML page defined in `www/index.html`.
+
+## Development
+
+The integration registers the HTML page under `/custom_ui_panel/index.html` and uses Home Assistant's built-in `iframe` panel to display it.
+
+You can modify `www/index.html` to add your own custom UI elements.

--- a/custom_components/custom_ui_panel/__init__.py
+++ b/custom_components/custom_ui_panel/__init__.py
@@ -1,0 +1,27 @@
+"""Custom UI Panel integration."""
+
+from __future__ import annotations
+
+import logging
+
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.typing import ConfigType
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
+    """Set up the custom UI panel integration."""
+    _LOGGER.debug("Setting up custom UI panel")
+
+    hass.http.register_static_path("/custom_ui_panel", hass.config.path("custom_components/custom_ui_panel/www"), False)
+    hass.components.frontend.async_register_built_in_panel(
+        component_name="iframe",
+        sidebar_title="Custom Panel",
+        sidebar_icon="mdi:monitor-dashboard",
+        frontend_url_path="custom-ui-panel",
+        config={"url": "/custom_ui_panel/index.html"},
+        require_admin=False,
+    )
+
+    return True

--- a/custom_components/custom_ui_panel/manifest.json
+++ b/custom_components/custom_ui_panel/manifest.json
@@ -1,0 +1,8 @@
+{
+  "domain": "custom_ui_panel",
+  "name": "Custom UI Panel",
+  "documentation": "https://github.com/example/custom_ui_panel",
+  "requirements": [],
+  "dependencies": ["panel_custom"],
+  "codeowners": []
+}

--- a/custom_components/custom_ui_panel/www/index.html
+++ b/custom_components/custom_ui_panel/www/index.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Custom UI Panel</title>
+    <meta charset="utf-8">
+    <style>
+        body { font-family: Arial, sans-serif; padding: 2em; }
+    </style>
+</head>
+<body>
+    <h1>Hello from Custom UI Panel</h1>
+    <p>This is a simple custom panel served by the custom_ui_panel integration.</p>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add README instructions
- create a `custom_ui_panel` integration with a basic HTML panel

## Testing
- `python3 -m py_compile custom_components/custom_ui_panel/__init__.py`


------
https://chatgpt.com/codex/tasks/task_e_684eb0937c1083238a74dc8d2d5d7051